### PR TITLE
[SS-23] extract reusable styles to styles.dart and clean up login.dart

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "editor.formatOnSave": true
+}

--- a/lib/login.dart
+++ b/lib/login.dart
@@ -50,7 +50,7 @@ class _LoginState extends State<Login> {
                   ),
                   //TEXTFIELD OF PASSWORD
                   Padding(
-                    padding: const EdgeInsets.fromLTRB(0, 30, 0, 30),
+                    padding: const EdgeInsets.symmetric(vertical: 30),
                     child: TextFormField(
                       cursorColor: Colors.black,
                       obscureText: isPassVisible,
@@ -72,7 +72,7 @@ class _LoginState extends State<Login> {
                   ),
                   // ELEVATED BUTTON OF LOG IN
                   Padding(
-                    padding: const EdgeInsets.fromLTRB(0, 15, 0, 10),
+                    padding: const EdgeInsets.only(top: 15, bottom: 10),
                     child: SizedBox(
                       height: 70,
                       width: MediaQuery.of(context).size.width,

--- a/lib/login.dart
+++ b/lib/login.dart
@@ -31,7 +31,7 @@ class _LoginState extends State<Login> {
                     ),
                   ),
                   const Text(
-                    style: AppStyle.headingText, // NEW ADDITION IN THE CODE
+                    style: AppStyle.headingText,
                     'Welcome back!',
                   ),
                   //TEXTFORMFIELD OF EMAIL
@@ -79,20 +79,18 @@ class _LoginState extends State<Login> {
                       child: ElevatedButton(
                         onPressed: () {},
                         style: AppStyle
-                            .elevatedButtonStyle, // NEW ADDITION IN THE CODE
+                            .elevatedButtonStyle,
                         child: const Text(
-                          style: AppStyle
-                              .loginButtonText, // NEW ADDITION IN THE CODE
                           'Log In',
                         ),
                       ),
                     ),
-                  ),
+                  ),  
                   //FORGOT PASSWORD
                   const Padding(
                     padding: EdgeInsets.all(10),
                     child: Text(
-                      style: AppStyle.hintText, // NEW ADDITION IN THE CODE
+                      style: AppStyle.hintText,
                       'Forgot password',
                     ),
                   ),

--- a/lib/login.dart
+++ b/lib/login.dart
@@ -78,14 +78,13 @@ class _LoginState extends State<Login> {
                       width: MediaQuery.of(context).size.width,
                       child: ElevatedButton(
                         onPressed: () {},
-                        style: AppStyle
-                            .elevatedButtonStyle,
+                        style: AppStyle.elevatedButtonStyle,
                         child: const Text(
                           'Log In',
                         ),
                       ),
                     ),
-                  ),  
+                  ),
                   //FORGOT PASSWORD
                   const Padding(
                     padding: EdgeInsets.all(10),

--- a/lib/login.dart
+++ b/lib/login.dart
@@ -1,158 +1,107 @@
 import 'package:flutter/material.dart';
+import 'package:syncserve/styles.dart';
 
-class Login extends StatefulWidget{
-
-  const Login ({super.key});
+class Login extends StatefulWidget {
+  const Login({super.key});
 
   @override
   State<Login> createState() => _LoginState();
 }
-class _LoginState extends State <Login> {
 
+class _LoginState extends State<Login> {
   bool isPassVisible = true;
 
   @override
   Widget build(BuildContext context) {
-      return Scaffold(
-        body: SafeArea(
-          child: Center(
-            child: SingleChildScrollView(
-              child: Padding(
-                 padding: const EdgeInsets.symmetric(horizontal: 24.0),
-                 child: Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                Padding(
-                  padding: const EdgeInsets.only(bottom: 40),
-                  child: Container(
-                  color: Colors.grey,
-                  height: 80,
-                  width: 100,
+    return Scaffold(
+      body: SafeArea(
+        child: Center(
+          child: SingleChildScrollView(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 24.0),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: 40),
+                    child: Container(
+                      color: Colors.grey,
+                      height: 80,
+                      width: 100,
+                    ),
                   ),
-                ),
-              const Text(
-                style: TextStyle(
-                  fontWeight: FontWeight.bold,
-                  fontSize: 30,
-                  color: Colors.black,
-                ),
-                "Welcome back!"
-              ),
-            //TEXTFORMFIELD OF EMAIL
-            Padding(
-              padding: const EdgeInsets.fromLTRB(0, 30, 0, 10),
-              child: TextFormField(
-                keyboardType: TextInputType.emailAddress,
-                 autofillHints: const [AutofillHints.email],
-                 autocorrect: false,
-                cursorColor: Colors.black,
-                decoration: InputDecoration(
-                    hintText: 'Email',
-                    hintStyle: const TextStyle(
-                      fontSize: 18,
-                      color: Colors.grey,
-                    ),
-                    contentPadding: const EdgeInsets.symmetric(
-                        vertical: 22, horizontal: 10,),
-                    enabledBorder: OutlineInputBorder(
-                      borderSide: const BorderSide(
-                        color: Colors.black,
+                  const Text(
+                    style: AppStyle.headingText, // NEW ADDITION IN THE CODE
+                    'Welcome back!',
+                  ),
+                  //TEXTFORMFIELD OF EMAIL
+                  Padding(
+                    padding: const EdgeInsets.fromLTRB(0, 30, 0, 10),
+                    child: TextFormField(
+                      //TEXTFIELD COMMON STYLES FOR EMAIL AND PASSWORD
+                      keyboardType: TextInputType.emailAddress,
+                      autofillHints: const [AutofillHints.email],
+                      autocorrect: false,
+                      cursorColor: Colors.black,
+                      decoration: AppStyle.inputDecoration(
+                        'Email',
                       ),
-                      borderRadius: BorderRadius.circular(15),
                     ),
-                    focusedBorder: OutlineInputBorder(
-                      borderSide: const BorderSide(
-                        color: Colors.black,
-                      ),
-                      borderRadius: BorderRadius.circular(15),
-                    ),
-                ),
-              ),
-            ),
-            //TEXTFIELD OF PASSWORD
-             Padding(
-              padding: const EdgeInsets.fromLTRB(0, 30, 0, 30),
-              child: TextFormField(
-                cursorColor: Colors.black,
-                obscureText: isPassVisible,
-                decoration: InputDecoration(
-                    hintText: 'Password',
-                    hintStyle: const TextStyle(
-                      fontSize: 18,
-                      color: Colors.grey,
-                    ),
-                    contentPadding: const EdgeInsets.symmetric(
-                        vertical: 22, horizontal: 10,),
-                    enabledBorder: OutlineInputBorder(
-                      borderSide: const BorderSide(
-                        color: Colors.black,
-                      ),
-                      borderRadius: BorderRadius.circular(15),
-                    ),
-                    focusedBorder: OutlineInputBorder(
-                      borderSide: const BorderSide(
-                        color: Colors.black,
-                      ),
-                      borderRadius: BorderRadius.circular(15),
-                    ),
-                    suffixIcon: IconButton(
-                        onPressed: () {
-                          setState(() {
-                            isPassVisible = !isPassVisible;
-                          });
-                        },
-                        icon: Icon(
-                            isPassVisible ? Icons.visibility_off : Icons
-                                .visibility,
+                  ),
+                  //TEXTFIELD OF PASSWORD
+                  Padding(
+                    padding: const EdgeInsets.fromLTRB(0, 30, 0, 30),
+                    child: TextFormField(
+                      cursorColor: Colors.black,
+                      obscureText: isPassVisible,
+                      decoration: AppStyle.inputDecoration('Password').copyWith(
+                        suffixIcon: IconButton(
+                          onPressed: () {
+                            setState(() {
+                              isPassVisible = !isPassVisible;
+                            });
+                          },
+                          icon: Icon(
+                            isPassVisible
+                                ? Icons.visibility_off
+                                : Icons.visibility,
+                          ),
                         ),
+                      ),
                     ),
-                ),
-              ),
-            ),
-            //GESTURE DETECTOR OF LOG IN
-            Padding(
-              padding: const EdgeInsets.fromLTRB(0, 20, 0, 10),
-              child: GestureDetector(
-                child: Container(
-                  alignment: Alignment.center,
-                  decoration: BoxDecoration(
-                    color: const Color.fromARGB(255, 237, 125, 125),
-                    borderRadius: BorderRadius.circular(15),
                   ),
-                  height: 70,
-                  width: MediaQuery
-                      .of(context)
-                      .size
-                      .width,
-                  child: const Text(
-                    style: TextStyle(
-                      fontSize: 20,
-                      color: Colors.white,
-                      fontWeight: FontWeight.bold,
+                  // ELEVATED BUTTON OF LOG IN
+                  Padding(
+                    padding: const EdgeInsets.fromLTRB(0, 15, 0, 10),
+                    child: SizedBox(
+                      height: 70,
+                      width: MediaQuery.of(context).size.width,
+                      child: ElevatedButton(
+                        onPressed: () {},
+                        style: AppStyle
+                            .elevatedButtonStyle, // NEW ADDITION IN THE CODE
+                        child: const Text(
+                          style: AppStyle
+                              .loginButtonText, // NEW ADDITION IN THE CODE
+                          'Log In',
+                        ),
+                      ),
                     ),
-                    'Log In',
                   ),
-                ),
+                  //FORGOT PASSWORD
+                  const Padding(
+                    padding: EdgeInsets.all(10),
+                    child: Text(
+                      style: AppStyle.hintText, // NEW ADDITION IN THE CODE
+                      'Forgot password',
+                    ),
+                  ),
+                ],
               ),
             ),
-            //FORGOT PASSWORD
-            const Padding(
-              padding: EdgeInsets.all(10),
-              child: Text(
-                  style: TextStyle(
-                    decoration: TextDecoration.underline,
-                    decorationColor: Colors.black,
-                    color: Colors.black,
-                  ),
-                  'Forgot password',
-              ),
-            ),
-              ]
-              ),
-                ),
+          ),
         ),
-        )
-      )
+      ),
     );
-      }
-    }
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,16 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:syncserve/login.dart';
 
-
-void main(){
+void main() {
   runApp(const MyApp());
 }
-class MyApp extends StatelessWidget{
+
+class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
   @override
-  Widget build(BuildContext context){
-    
+  Widget build(BuildContext context) {
     return const MaterialApp(
       home: Login(),
     );

--- a/lib/styles.dart
+++ b/lib/styles.dart
@@ -23,20 +23,19 @@ class AppStyle {
     color: Colors.black,
   );
 
-// Login button text
-  static const TextStyle loginButtonText = TextStyle(
-    fontSize: 20,
-    color: Colors.white,
-    fontWeight: FontWeight.bold,
-  );
-
 // Elevated Button
-  static ButtonStyle elevatedButtonStyle = ElevatedButton.styleFrom(
+  static final ButtonStyle elevatedButtonStyle = ElevatedButton.styleFrom(
     backgroundColor: const Color.fromARGB(255, 237, 125, 125),
     minimumSize: const Size(double.infinity, 60),
     shape: RoundedRectangleBorder(
       borderRadius: BorderRadius.circular(16),
     ),
+    textStyle: const TextStyle(
+    fontSize: 20,
+    color: Colors.white,
+    fontWeight: FontWeight.bold,
+    ),
+  foregroundColor: Colors.white,
   );
 
 //EMAIL AND PASSWORD TEXTFORMFIELD

--- a/lib/styles.dart
+++ b/lib/styles.dart
@@ -31,11 +31,11 @@ class AppStyle {
       borderRadius: BorderRadius.circular(16),
     ),
     textStyle: const TextStyle(
-    fontSize: 20,
-    color: Colors.white,
-    fontWeight: FontWeight.bold,
+      fontSize: 20,
+      color: Colors.white,
+      fontWeight: FontWeight.bold,
     ),
-  foregroundColor: Colors.white,
+    foregroundColor: Colors.white,
   );
 
 //EMAIL AND PASSWORD TEXTFORMFIELD

--- a/lib/styles.dart
+++ b/lib/styles.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+
+///1: TEXT STYLES///
+
+// Welcome back
+class AppStyle {
+  static const TextStyle headingText = TextStyle(
+    fontWeight: FontWeight.bold,
+    fontSize: 30,
+    color: Colors.black,
+  );
+
+// Hint text for input fields
+  static const TextStyle hintText = TextStyle(
+    fontSize: 18,
+    color: Colors.grey,
+  );
+
+// "Forgot password"
+  static const TextStyle forgotPasswordText = TextStyle(
+    decoration: TextDecoration.underline,
+    decorationColor: Colors.black,
+    color: Colors.black,
+  );
+
+// Login button text
+  static const TextStyle loginButtonText = TextStyle(
+    fontSize: 20,
+    color: Colors.white,
+    fontWeight: FontWeight.bold,
+  );
+
+// Elevated Button
+  static ButtonStyle elevatedButtonStyle = ElevatedButton.styleFrom(
+    backgroundColor: const Color.fromARGB(255, 237, 125, 125),
+    minimumSize: const Size(double.infinity, 60),
+    shape: RoundedRectangleBorder(
+      borderRadius: BorderRadius.circular(16),
+    ),
+  );
+
+//EMAIL AND PASSWORD TEXTFORMFIELD
+  static InputDecoration inputDecoration(String hint) {
+    return InputDecoration(
+      hintText: hint,
+      contentPadding: const EdgeInsets.symmetric(vertical: 22, horizontal: 10),
+      enabledBorder: OutlineInputBorder(
+        borderSide: const BorderSide(color: Colors.black),
+        borderRadius: BorderRadius.circular(15),
+      ),
+      focusedBorder: OutlineInputBorder(
+        borderSide: const BorderSide(color: Colors.black),
+        borderRadius: BorderRadius.circular(15),
+      ),
+    );
+  }
+}

--- a/lib/styles.dart
+++ b/lib/styles.dart
@@ -16,7 +16,8 @@ class AppStyle {
     color: Colors.grey,
   );
 
-// "Forgot password"
+// forgotPasswordText
+// rename this once it is reused
   static const TextStyle forgotPasswordText = TextStyle(
     decoration: TextDecoration.underline,
     decorationColor: Colors.black,


### PR DESCRIPTION
Moved repetitive styling code from login.dart to a new styles.dart file for better reusability and cleaner structure. This improves code readability and makes style management easier across the app.
### Changes 

Wasn't able to add styles to a textfield So - decoration: I've wrote InputDecoration in the styles.dart file and returned a method to it
