### PR TITLE
[SS-48] Riverpod for Service_form page

### DIFF
--- a/lib/helpers/service_form_helper.dart
+++ b/lib/helpers/service_form_helper.dart
@@ -1,0 +1,15 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+void toggleItem<T>(
+  WidgetRef ref,
+  StateProvider<Set<T>> provider,
+  T item,
+  bool? isChecked,
+) {
+  final current = ref.read(provider);
+  final updated = Set<T>.from(current);
+
+  isChecked == true ? updated.add(item) : updated.remove(item);
+
+  ref.read(provider.notifier).state = updated;
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -362,7 +362,7 @@
     "@manufacturerName": {
         "description": "Label for the manufacturer's Textfield"
     },
-    "manufacturerNameRequired": "Enter manufacturer",
+    "manufacturerNameRequired": "Enter manufacturer name",
     "@manufacturerNameRequired": {
         "description": "Error message shown when manufacturer name is empty"
     },
@@ -573,6 +573,7 @@
     "wPhaseShort": "W",
     "@wPhaseShort": {
         "description": "Unit for the electrical page textfield"
+    },
     "userDisabled": "Your account has been disabled. Please contact admin.",
     "@userDisabled": {
         "description": "Error message when user account is disabled"
@@ -601,4 +602,4 @@
     "@withStabilizer": {
         "description": "Label for checkbox in readings page"
     }
-}
+    }

--- a/lib/model/service_form_model.dart
+++ b/lib/model/service_form_model.dart
@@ -1,0 +1,15 @@
+import 'package:syncserve/enums/service_form.dart';
+
+class ServiceFormModel {
+  ServiceFormModel({
+    required this.reasons,
+    required this.categories,
+    required this.systems,
+    required this.manufacturerName,
+  });
+
+  final Set<ServiceReasons> reasons;
+  final Set<ServiceCategory> categories;
+  final Set<ServiceSystemType> systems;
+  final String manufacturerName;
+}

--- a/lib/providers/service_form_providers.dart
+++ b/lib/providers/service_form_providers.dart
@@ -1,0 +1,14 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:syncserve/enums/service_form.dart';
+import 'package:syncserve/model/service_form_model.dart';
+
+final serviceFormProvider = StateProvider<ServiceFormModel?>((ref) => null);
+
+final visitReasonProvider = StateProvider<Set<ServiceReasons>>((ref) => {});
+
+final serviceCategoryProvider =
+    StateProvider<Set<ServiceCategory>>((ref) => {});
+
+final systemTypeProvider = StateProvider<Set<ServiceSystemType>>((ref) => {});
+
+final manufacturerNameProvider = StateProvider<String>((ref) => '');

--- a/lib/view/service_form.dart
+++ b/lib/view/service_form.dart
@@ -1,21 +1,24 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:syncserve/enums/service_form.dart';
+import 'package:syncserve/providers/service_form_providers.dart';
 import 'package:syncserve/theme/styles.dart';
 import 'package:syncserve/custom_controls/labeled_checkbox.dart';
 import 'package:syncserve/view/service_checklist.dart';
 import 'package:zod_validation/zod_validation.dart';
 import 'package:syncserve/view_model/service_form_view_model.dart';
+import 'package:syncserve/helpers/service_form_helper.dart';
 import 'package:syncserve/theme/app_paddings.dart';
 
-class ServiceForm extends StatefulWidget {
+class ServiceForm extends ConsumerStatefulWidget {
   const ServiceForm({super.key});
 
   @override
-  State<ServiceForm> createState() => _ServiceFormState();
+  ConsumerState<ServiceForm> createState() => _ServiceFormState();
 }
 
-class _ServiceFormState extends State<ServiceForm> {
+class _ServiceFormState extends ConsumerState<ServiceForm> {
   final _formKey = GlobalKey<FormState>();
   ServiceFormViewModel viewModel = ServiceFormViewModel();
   final TextEditingController controller = TextEditingController();
@@ -36,8 +39,25 @@ class _ServiceFormState extends State<ServiceForm> {
     super.dispose();
   }
 
+  void _onNextPressed() {
+    bool isValid = _formKey.currentState?.validate() ?? false;
+
+    if (isValid) {
+      Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder: (context) => ServiceChecklist(),
+        ),
+      );
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
+    final selectedReasons = ref.watch(visitReasonProvider);
+    final selectedCategories = ref.watch(serviceCategoryProvider);
+    final selectedSystems = ref.watch(systemTypeProvider);
+    final manufacturerName = ref.watch(manufacturerNameProvider);
     return Scaffold(
       appBar: AppBar(
         backgroundColor: AppStyle.appBarNavBarCardAndCanvasColor,
@@ -74,19 +94,16 @@ class _ServiceFormState extends State<ServiceForm> {
                                     child: LabeledCheckbox(
                                       label: AppLocalizations.of(context)!
                                           .installation,
-                                      value: viewModel.reasons.contains(
+                                      value: selectedReasons.contains(
                                         ServiceReasons.installation,
                                       ),
                                       onChanged: (value) {
-                                        setState(() {
-                                          value
-                                              ? viewModel.reasons.add(
-                                                  ServiceReasons.installation,
-                                                )
-                                              : viewModel.reasons.remove(
-                                                  ServiceReasons.installation,
-                                                );
-                                        });
+                                        toggleItem<ServiceReasons>(
+                                          ref,
+                                          visitReasonProvider,
+                                          ServiceReasons.installation,
+                                          value,
+                                        );
                                       },
                                     ),
                                   ),
@@ -94,18 +111,16 @@ class _ServiceFormState extends State<ServiceForm> {
                                     child: LabeledCheckbox(
                                       label: AppLocalizations.of(context)!
                                           .callBasis,
-                                      value: viewModel.reasons
-                                          .contains(ServiceReasons.callBasis),
+                                      value: selectedReasons.contains(
+                                        ServiceReasons.callBasis,
+                                      ),
                                       onChanged: (value) {
-                                        setState(() {
-                                          value
-                                              ? viewModel.reasons.add(
-                                                  ServiceReasons.callBasis,
-                                                )
-                                              : viewModel.reasons.remove(
-                                                  ServiceReasons.callBasis,
-                                                );
-                                        });
+                                        toggleItem<ServiceReasons>(
+                                          ref,
+                                          visitReasonProvider,
+                                          ServiceReasons.callBasis,
+                                          value,
+                                        );
                                       },
                                     ),
                                   ),
@@ -114,21 +129,16 @@ class _ServiceFormState extends State<ServiceForm> {
                               LabeledCheckbox(
                                 label: AppLocalizations.of(context)!
                                     .preventiveMaintenance,
-                                value: viewModel.reasons.contains(
+                                value: selectedReasons.contains(
                                   ServiceReasons.preventiveMaintenance,
                                 ),
                                 onChanged: (value) {
-                                  setState(() {
-                                    value
-                                        ? viewModel.reasons.add(
-                                            ServiceReasons
-                                                .preventiveMaintenance,
-                                          )
-                                        : viewModel.reasons.remove(
-                                            ServiceReasons
-                                                .preventiveMaintenance,
-                                          );
-                                  });
+                                  toggleItem<ServiceReasons>(
+                                    ref,
+                                    visitReasonProvider,
+                                    ServiceReasons.preventiveMaintenance,
+                                    value,
+                                  );
                                 },
                               ),
                             ],
@@ -158,19 +168,16 @@ class _ServiceFormState extends State<ServiceForm> {
                                     child: LabeledCheckbox(
                                       label: AppLocalizations.of(context)!
                                           .inWarranty,
-                                      value: viewModel.category.contains(
+                                      value: selectedCategories.contains(
                                         ServiceCategory.inWarranty,
                                       ),
                                       onChanged: (value) {
-                                        setState(() {
-                                          value
-                                              ? viewModel.category.add(
-                                                  ServiceCategory.inWarranty,
-                                                )
-                                              : viewModel.category.remove(
-                                                  ServiceCategory.inWarranty,
-                                                );
-                                        });
+                                        toggleItem<ServiceCategory>(
+                                          ref,
+                                          serviceCategoryProvider,
+                                          ServiceCategory.inWarranty,
+                                          value,
+                                        );
                                       },
                                     ),
                                   ),
@@ -178,19 +185,16 @@ class _ServiceFormState extends State<ServiceForm> {
                                     child: LabeledCheckbox(
                                       label: AppLocalizations.of(context)!
                                           .inFreeService,
-                                      value: viewModel.category.contains(
+                                      value: selectedCategories.contains(
                                         ServiceCategory.inFreeService,
                                       ),
                                       onChanged: (value) {
-                                        setState(() {
-                                          value
-                                              ? viewModel.category.add(
-                                                  ServiceCategory.inFreeService,
-                                                )
-                                              : viewModel.category.remove(
-                                                  ServiceCategory.inFreeService,
-                                                );
-                                        });
+                                        toggleItem<ServiceCategory>(
+                                          ref,
+                                          serviceCategoryProvider,
+                                          ServiceCategory.inFreeService,
+                                          value,
+                                        );
                                       },
                                     ),
                                   ),
@@ -199,21 +203,16 @@ class _ServiceFormState extends State<ServiceForm> {
                               LabeledCheckbox(
                                 label: AppLocalizations.of(context)!
                                     .inAnnualMaintenanceContract,
-                                value: viewModel.category.contains(
+                                value: selectedCategories.contains(
                                   ServiceCategory.inAnnualMaintenanceContract,
                                 ),
                                 onChanged: (value) {
-                                  setState(() {
-                                    value
-                                        ? viewModel.category.add(
-                                            ServiceCategory
-                                                .inAnnualMaintenanceContract,
-                                          )
-                                        : viewModel.category.remove(
-                                            ServiceCategory
-                                                .inAnnualMaintenanceContract,
-                                          );
-                                  });
+                                  toggleItem<ServiceCategory>(
+                                    ref,
+                                    serviceCategoryProvider,
+                                    ServiceCategory.inAnnualMaintenanceContract,
+                                    value,
+                                  );
                                 },
                               ),
                             ],
@@ -242,19 +241,16 @@ class _ServiceFormState extends State<ServiceForm> {
                                   Expanded(
                                     child: LabeledCheckbox(
                                       label: AppLocalizations.of(context)!.ups,
-                                      value: viewModel.systemType.contains(
+                                      value: selectedSystems.contains(
                                         ServiceSystemType.ups,
                                       ),
                                       onChanged: (value) {
-                                        setState(() {
-                                          value
-                                              ? viewModel.systemType.add(
-                                                  ServiceSystemType.ups,
-                                                )
-                                              : viewModel.systemType.remove(
-                                                  ServiceSystemType.ups,
-                                                );
-                                        });
+                                        toggleItem<ServiceSystemType>(
+                                          ref,
+                                          systemTypeProvider,
+                                          ServiceSystemType.ups,
+                                          value,
+                                        );
                                       },
                                     ),
                                   ),
@@ -262,19 +258,16 @@ class _ServiceFormState extends State<ServiceForm> {
                                     child: LabeledCheckbox(
                                       label: AppLocalizations.of(context)!
                                           .generator,
-                                      value: viewModel.systemType.contains(
+                                      value: selectedSystems.contains(
                                         ServiceSystemType.generator,
                                       ),
                                       onChanged: (value) {
-                                        setState(() {
-                                          value
-                                              ? viewModel.systemType.add(
-                                                  ServiceSystemType.generator,
-                                                )
-                                              : viewModel.systemType.remove(
-                                                  ServiceSystemType.generator,
-                                                );
-                                        });
+                                        toggleItem<ServiceSystemType>(
+                                          ref,
+                                          systemTypeProvider,
+                                          ServiceSystemType.generator,
+                                          value,
+                                        );
                                       },
                                     ),
                                   ),
@@ -286,19 +279,16 @@ class _ServiceFormState extends State<ServiceForm> {
                                     child: LabeledCheckbox(
                                       label: AppLocalizations.of(context)!
                                           .stabilizer,
-                                      value: viewModel.systemType.contains(
+                                      value: selectedSystems.contains(
                                         ServiceSystemType.stabilizer,
                                       ),
                                       onChanged: (value) {
-                                        setState(() {
-                                          value
-                                              ? viewModel.systemType.add(
-                                                  ServiceSystemType.stabilizer,
-                                                )
-                                              : viewModel.systemType.remove(
-                                                  ServiceSystemType.stabilizer,
-                                                );
-                                        });
+                                        toggleItem<ServiceSystemType>(
+                                          ref,
+                                          systemTypeProvider,
+                                          ServiceSystemType.stabilizer,
+                                          value,
+                                        );
                                       },
                                     ),
                                   ),
@@ -306,19 +296,16 @@ class _ServiceFormState extends State<ServiceForm> {
                                     child: LabeledCheckbox(
                                       label: AppLocalizations.of(context)!
                                           .inverter,
-                                      value: viewModel.systemType.contains(
+                                      value: selectedSystems.contains(
                                         ServiceSystemType.inverter,
                                       ),
                                       onChanged: (value) {
-                                        setState(() {
-                                          value
-                                              ? viewModel.systemType.add(
-                                                  ServiceSystemType.inverter,
-                                                )
-                                              : viewModel.systemType.remove(
-                                                  ServiceSystemType.inverter,
-                                                );
-                                        });
+                                        toggleItem<ServiceSystemType>(
+                                          ref,
+                                          systemTypeProvider,
+                                          ServiceSystemType.inverter,
+                                          value,
+                                        );
                                       },
                                     ),
                                   ),
@@ -330,6 +317,7 @@ class _ServiceFormState extends State<ServiceForm> {
                         Padding(
                           padding: const EdgeInsets.fromLTRB(10, 15, 10, 0),
                           child: TextFormField(
+                            initialValue: manufacturerName,
                             validator: (value) {
                               if (value == null || value.trim().isEmpty) {
                                 return AppLocalizations.of(context)!
@@ -340,23 +328,15 @@ class _ServiceFormState extends State<ServiceForm> {
                                     AppLocalizations.of(context)!
                                         .manufacturerNameRequired,
                                   )
-                                  .min(
-                                    3,
-                                    AppLocalizations.of(context)!
-                                        .manufacturerNameTooShort,
-                                  )
                                   .build(value);
                             },
-                            controller: controller,
                             decoration: AppStyle.inputDecorationWithLabel(
                               AppLocalizations.of(context)!.manufacturerName,
                             ),
-                            autovalidateMode: AutovalidateMode.onUnfocus,
                             onChanged: (value) {
-                              setState(() {
-                                viewModel.manufacturerName = value;
-                                _formKey.currentState?.validate();
-                              });
+                              ref
+                                  .read(manufacturerNameProvider.notifier)
+                                  .state = value;
                             },
                           ),
                         ),
@@ -370,18 +350,7 @@ class _ServiceFormState extends State<ServiceForm> {
               padding: AppPaddings.bottomAreaPadding,
               child: ElevatedButton(
                 style: AppStyle.primaryElevatedButtonStyle(),
-                onPressed: viewModel.isValid
-                    ? () {
-                        if (_formKey.currentState!.validate()) {
-                          Navigator.push(
-                            context,
-                            MaterialPageRoute(
-                              builder: (context) => ServiceChecklist(),
-                            ),
-                          );
-                        }
-                      }
-                    : null,
+                onPressed: _onNextPressed,
                 child: Text(AppLocalizations.of(context)!.next),
               ),
             ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -557,14 +557,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
-  plugin_platform_interface:
-    dependency: transitive
-    description:
-      name: plugin_platform_interface
-      sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.1.8"
   path_parsing:
     dependency: transitive
     description:
@@ -581,6 +573,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.0"
+  plugin_platform_interface:
+    dependency: transitive
+    description:
+      name: plugin_platform_interface
+      sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.8"
   pool:
     dependency: transitive
     description:


### PR DESCRIPTION
- Converted ServiceFormPage to ConsumerStatefulWidget
- Introduced StateProviders in service_form_providers.dart
- Created a unified ServiceFormModel class to bundle selected fields into a single object
- Added ServiceFormViewModel.save(ref) to convert individual provider states into a clean model instance
- Refactored checkbox toggling using a shared toggleItem<T>() utility for clean, reusable state updates