### PR TITLE
[SS-48] Implement Riverpod on Service_checklist

### DIFF
--- a/lib/model/service_checklist_model.dart
+++ b/lib/model/service_checklist_model.dart
@@ -4,10 +4,11 @@ class ServiceChecklistItem {
   ServiceChecklistItem({
     required this.label,
     required this.flag,
+    this.isChecked = false,
   });
 
   /// The label for the checklist item.
   final String label;
-
+  bool isChecked;
   final ServiceChecklistFlag flag;
 }

--- a/lib/providers/service_checklist_providers.dart
+++ b/lib/providers/service_checklist_providers.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:syncserve/model/service_checklist_model.dart';
+import 'package:syncserve/enums/service_checklist.dart';
+import 'package:syncserve/utils/flags.dart';
 
 final serviceChecklistProvider =
-    StateProvider<List<ServiceChecklistItem>>((ref) => []);
+    StateProvider<EnumFlags<ServiceChecklistFlag>>((ref) => EnumFlags());

--- a/lib/providers/service_checklist_providers.dart
+++ b/lib/providers/service_checklist_providers.dart
@@ -1,0 +1,5 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:syncserve/model/service_checklist_model.dart';
+
+final serviceChecklistProvider =
+    StateProvider<List<ServiceChecklistItem>>((ref) => []);

--- a/lib/view/service_checklist.dart
+++ b/lib/view/service_checklist.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:syncserve/enums/service_checklist.dart';
-import 'package:syncserve/utils/flags.dart';
 import 'package:syncserve/view/readings_page.dart';
 import 'package:syncserve/theme/styles.dart';
 import 'package:syncserve/view_model/service_checklist_view_model.dart';
@@ -26,18 +24,17 @@ class ServiceChecklistView extends ConsumerStatefulWidget {
 }
 
 class _ServiceChecklistViewState extends ConsumerState<ServiceChecklistView> {
-  final EnumFlags<ServiceChecklistFlag> flags = EnumFlags();
   ServiceChecklistViewModel? viewModel;
 
   @override
   void initState() {
     super.initState();
-    // Initialize after the widget is fully mounted
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      setState(() {
-        viewModel = ServiceChecklistViewModel(AppLocalizations.of(context)!);
-      });
-    });
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    viewModel ??= ServiceChecklistViewModel(AppLocalizations.of(context)!);
   }
 
   @override
@@ -78,14 +75,11 @@ class _ServiceChecklistViewState extends ConsumerState<ServiceChecklistView> {
                   itemCount: viewModel!.items.length,
                   itemBuilder: (context, index) {
                     final item = viewModel!.items[index];
-                    final isChecked = flags.contains(item.flag);
                     return CheckboxListTile(
-                      value: isChecked,
-                      onChanged: (_) {
+                      value: item.isChecked,
+                      onChanged: (bool? value) {
                         setState(() {
-                          isChecked
-                              ? flags.remove(item.flag)
-                              : flags.add(item.flag);
+                          item.isChecked = value ?? false;
                         });
                       },
                       title: Text(

--- a/lib/view/service_checklist.dart
+++ b/lib/view/service_checklist.dart
@@ -26,7 +26,6 @@ class ServiceChecklistView extends ConsumerStatefulWidget {
 }
 
 class _ServiceChecklistViewState extends ConsumerState<ServiceChecklistView> {
-  final _formKey = GlobalKey<FormState>();
   final EnumFlags<ServiceChecklistFlag> flags = EnumFlags();
   ServiceChecklistViewModel? viewModel;
 
@@ -47,17 +46,13 @@ class _ServiceChecklistViewState extends ConsumerState<ServiceChecklistView> {
   }
 
   void _onNextPressed() {
-    bool isValid = _formKey.currentState?.validate() ?? false;
-
-    if (isValid) {
-      viewModel!.save(ref);
-      Navigator.push(
-        context,
-        MaterialPageRoute(
-          builder: (context) => ReadingsPage(),
-        ),
-      );
-    }
+    viewModel!.save(ref);
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (context) => ReadingsPage(),
+      ),
+    );
   }
 
   @override
@@ -74,48 +69,45 @@ class _ServiceChecklistViewState extends ConsumerState<ServiceChecklistView> {
         title: Text(AppLocalizations.of(context)!.title),
       ),
       body: SafeArea(
-        child: Form(
-          key: _formKey,
-          child: Column(
-            children: [
-              Expanded(
-                child: Padding(
-                  padding: const EdgeInsets.fromLTRB(10, 30, 10, 0),
-                  child: ListView.builder(
-                    itemCount: viewModel!.items.length,
-                    itemBuilder: (context, index) {
-                      final item = viewModel!.items[index];
-                      final isChecked = flags.contains(item.flag);
-                      return CheckboxListTile(
-                        value: isChecked,
-                        onChanged: (_) {
-                          setState(() {
-                            isChecked
-                                ? flags.remove(item.flag)
-                                : flags.add(item.flag);
-                          });
-                        },
-                        title: Text(
-                          item.label,
-                          style: AppStyle.labelText,
-                        ),
-                        controlAffinity: ListTileControlAffinity.leading,
-                        visualDensity: VisualDensity.comfortable,
-                      );
-                    },
-                  ),
+        child: Column(
+          children: [
+            Expanded(
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(10, 30, 10, 0),
+                child: ListView.builder(
+                  itemCount: viewModel!.items.length,
+                  itemBuilder: (context, index) {
+                    final item = viewModel!.items[index];
+                    final isChecked = flags.contains(item.flag);
+                    return CheckboxListTile(
+                      value: isChecked,
+                      onChanged: (_) {
+                        setState(() {
+                          isChecked
+                              ? flags.remove(item.flag)
+                              : flags.add(item.flag);
+                        });
+                      },
+                      title: Text(
+                        item.label,
+                        style: AppStyle.labelText,
+                      ),
+                      controlAffinity: ListTileControlAffinity.leading,
+                      visualDensity: VisualDensity.comfortable,
+                    );
+                  },
                 ),
               ),
-              Padding(
-                padding: AppPaddings.bottomAreaPadding,
-                child: ElevatedButton(
-                  style: AppStyle.primaryElevatedButtonStyle(),
-                  onPressed: _onNextPressed,
-                  child: Text(AppLocalizations.of(context)!.next),
-                ),
+            ),
+            Padding(
+              padding: AppPaddings.bottomAreaPadding,
+              child: ElevatedButton(
+                style: AppStyle.primaryElevatedButtonStyle(),
+                onPressed: _onNextPressed,
+                child: Text(AppLocalizations.of(context)!.next),
               ),
-            ],
-          ),
+            ),
+          ],
         ),
       ),
     );

--- a/lib/view/service_checklist.dart
+++ b/lib/view/service_checklist.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:syncserve/enums/service_checklist.dart';
 import 'package:syncserve/utils/flags.dart';
 import 'package:syncserve/view/readings_page.dart';
@@ -16,15 +17,17 @@ class ServiceChecklist extends StatelessWidget {
   }
 }
 
-class ServiceChecklistView extends StatefulWidget {
+class ServiceChecklistView extends ConsumerStatefulWidget {
   const ServiceChecklistView({super.key});
 
   @override
-  State<ServiceChecklistView> createState() => _ServiceChecklistViewState();
+  ConsumerState<ServiceChecklistView> createState() =>
+      _ServiceChecklistViewState();
 }
 
-class _ServiceChecklistViewState extends State<ServiceChecklistView> {
-  final EnumFlags<ServiceChecklistFlag> _flags = EnumFlags();
+class _ServiceChecklistViewState extends ConsumerState<ServiceChecklistView> {
+  final _formKey = GlobalKey<FormState>();
+  final EnumFlags<ServiceChecklistFlag> flags = EnumFlags();
   ServiceChecklistViewModel? viewModel;
 
   @override
@@ -36,6 +39,25 @@ class _ServiceChecklistViewState extends State<ServiceChecklistView> {
         viewModel = ServiceChecklistViewModel(AppLocalizations.of(context)!);
       });
     });
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+  }
+
+  void _onNextPressed() {
+    bool isValid = _formKey.currentState?.validate() ?? false;
+
+    if (isValid) {
+      viewModel!.save(ref);
+      Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder: (context) => ReadingsPage(),
+        ),
+      );
+    }
   }
 
   @override
@@ -52,52 +74,48 @@ class _ServiceChecklistViewState extends State<ServiceChecklistView> {
         title: Text(AppLocalizations.of(context)!.title),
       ),
       body: SafeArea(
-        child: Column(
-          children: [
-            Expanded(
-              child: Padding(
-                padding: const EdgeInsets.fromLTRB(10, 30, 10, 0),
-                child: ListView.builder(
-                  itemCount: viewModel!.items.length,
-                  itemBuilder: (context, index) {
-                    final item = viewModel!.items[index];
-                    final isChecked = _flags.contains(item.flag);
-                    return CheckboxListTile(
-                      value: isChecked,
-                      onChanged: (_) {
-                        setState(() {
-                          isChecked
-                              ? _flags.remove(item.flag)
-                              : _flags.add(item.flag);
-                        });
-                      },
-                      title: Text(
-                        item.label,
-                        style: AppStyle.labelText,
-                      ),
-                      controlAffinity: ListTileControlAffinity.leading,
-                      visualDensity: VisualDensity.comfortable,
-                    );
-                  },
+        child: Form(
+          key: _formKey,
+          child: Column(
+            children: [
+              Expanded(
+                child: Padding(
+                  padding: const EdgeInsets.fromLTRB(10, 30, 10, 0),
+                  child: ListView.builder(
+                    itemCount: viewModel!.items.length,
+                    itemBuilder: (context, index) {
+                      final item = viewModel!.items[index];
+                      final isChecked = flags.contains(item.flag);
+                      return CheckboxListTile(
+                        value: isChecked,
+                        onChanged: (_) {
+                          setState(() {
+                            isChecked
+                                ? flags.remove(item.flag)
+                                : flags.add(item.flag);
+                          });
+                        },
+                        title: Text(
+                          item.label,
+                          style: AppStyle.labelText,
+                        ),
+                        controlAffinity: ListTileControlAffinity.leading,
+                        visualDensity: VisualDensity.comfortable,
+                      );
+                    },
+                  ),
                 ),
               ),
-            ),
-            Padding(
-              padding: AppPaddings.bottomAreaPadding,
-              child: ElevatedButton(
-                style: AppStyle.primaryElevatedButtonStyle(),
-                onPressed: () {
-                  Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      builder: (context) => ReadingsPage(),
-                    ),
-                  );
-                },
-                child: Text(AppLocalizations.of(context)!.next),
+              Padding(
+                padding: AppPaddings.bottomAreaPadding,
+                child: ElevatedButton(
+                  style: AppStyle.primaryElevatedButtonStyle(),
+                  onPressed: _onNextPressed,
+                  child: Text(AppLocalizations.of(context)!.next),
+                ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/lib/view_model/service_checklist_view_model.dart
+++ b/lib/view_model/service_checklist_view_model.dart
@@ -1,6 +1,8 @@
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:syncserve/enums/service_checklist.dart';
 import 'package:syncserve/model/service_checklist_model.dart';
+import 'package:syncserve/providers/service_checklist_providers.dart';
 
 class ServiceChecklistViewModel {
   ServiceChecklistViewModel(AppLocalizations localizations) {
@@ -47,6 +49,19 @@ class ServiceChecklistViewModel {
       ),
     ];
   }
+  void save(WidgetRef ref) {
+    ref.read(serviceChecklistProvider.notifier).state = items;
+  }
 
-  late final List<ServiceChecklistItem> items;
+  void reset() {
+    for (var i = 0; i < items.length; i++) {
+      items[i] = ServiceChecklistItem(
+        label: items[i].label,
+        flag: items[i].flag,
+      );
+    }
+  }
+
+  bool get isValid => items.isNotEmpty;
+  late List<ServiceChecklistItem> items;
 }

--- a/lib/view_model/service_checklist_view_model.dart
+++ b/lib/view_model/service_checklist_view_model.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:syncserve/enums/service_checklist.dart';
 import 'package:syncserve/model/service_checklist_model.dart';
 import 'package:syncserve/providers/service_checklist_providers.dart';
+import 'package:syncserve/utils/flags.dart';
 
 class ServiceChecklistViewModel {
   ServiceChecklistViewModel(AppLocalizations localizations) {
@@ -50,15 +51,19 @@ class ServiceChecklistViewModel {
     ];
   }
   void save(WidgetRef ref) {
-    ref.read(serviceChecklistProvider.notifier).state = items;
+    final flags = EnumFlags<ServiceChecklistFlag>();
+
+    for (final item in items) {
+      if (item.isChecked) {
+        flags.add(item.flag);
+      }
+    }
+    ref.read(serviceChecklistProvider.notifier).state = flags;
   }
 
   void reset() {
-    for (var i = 0; i < items.length; i++) {
-      items[i] = ServiceChecklistItem(
-        label: items[i].label,
-        flag: items[i].flag,
-      );
+    for (var item in items) {
+      item.isChecked = false;
     }
   }
 

--- a/lib/view_model/service_checklist_view_model.dart
+++ b/lib/view_model/service_checklist_view_model.dart
@@ -62,6 +62,5 @@ class ServiceChecklistViewModel {
     }
   }
 
-  bool get isValid => items.isNotEmpty;
   late List<ServiceChecklistItem> items;
 }

--- a/lib/view_model/service_form_view_model.dart
+++ b/lib/view_model/service_form_view_model.dart
@@ -13,7 +13,7 @@ class ServiceFormViewModel {
       reasons: reasons,
       categories: category,
       systems: systemType,
-      manufacturerName: manufacturerName?.trim() ?? '',
+      manufacturerName: manufacturerName!.trim(),
     );
     ref.read(serviceFormProvider.notifier).state = model;
   }


### PR DESCRIPTION
- Implemented a save() method in ServiceChecklistViewModel to persist checklist items using Riverpod.
- Refactored items from late final to late to allow mutation during reset operations.
- Added a reset() method to reinitialize all checklist flags.
- Updated serviceChecklistProvider to use StateProvider<List<ServiceChecklistItem>>
- Ensured consistency in state management patterns across all the screens